### PR TITLE
新規会員登録実装99％完了

### DIFF
--- a/controllers/users_controller.php
+++ b/controllers/users_controller.php
@@ -13,16 +13,20 @@ session_start();
         $controller->signup($_POST);
         break;
 
+
+      
+      case 'create':
+        $controller->create($_POST);
+        break;
+      case 'check':
+        $controller->check();
+        break;
+
+
       case 'comfirm':
         $controller->comfirm();
         break;
 
-      case 'check':
-        $controller->check();
-        break;
-      case 'create':
-        $controller->create($_POST);
-        break;
       case 'thanks':
         $controller->thanks();
         break;
@@ -40,6 +44,8 @@ session_start();
   class UsersController {
       function signup($user_data) {
 
+
+       
 
 
          $error = array();
@@ -68,18 +74,48 @@ session_start();
               //blankは未入力
             }
 
-          //メールが未入力の場合
+
+
+
+
+          // メールが未入力の場合
             if (empty($user_data['email'])) {
                 // $error_email =  'メールアドレスを入力してくだささい。';
               $error['email'] = 'blank';
-              }
+
+              
+            }
+
+            //
+             $user = new User();
+      
+    
+             $return = $user->signup();
+
+             //重複登録時のエラー時
+             if (!empty($return)) {
+                // $error_email =  'メールアドレスを入力してくだささい。';
+              $error['email'] = 'duplicate';
+
+              
+            }
+
+
+
 
            //確認メールが未入力の場合
              if (empty($user_data['e_comfirm'])){
               // $error_nick_name =  'ニックネームを入力してくだささい。';
               $error['e_comfirm'] = 'blank';
               //blankは未入力
+            }elseif($user_data['email'] !== $user_data['e_comfirm']){
+             
+              $error['e_comfirm'] = 'notsame';
+
             }
+
+
+
 
 
                    //パスワードが未入力の場合
@@ -88,11 +124,15 @@ session_start();
                 // $error_password =  'パスワードを入力してくだささい。';
               $error['password'] = 'blank';
 
-            }elseif(strlen($user_data['password']) < 4){
+            }elseif(strlen($user_data['password']) < 8){
               //パスワードが４文字より少ない
               $error['password'] = 'length';
 
             }
+
+
+
+
 
 
           //パスワードが未入力の場合
@@ -101,15 +141,45 @@ session_start();
                 // $error_password =  'パスワードを入力してくだささい。';
               $error['p_comfirm'] = 'blank';
 
-            }elseif(strlen($user_data['password']) < 4){
+            }elseif(strlen($user_data['password']) < 8){
               //パスワードが４文字より少ない
               $error['p_comfirm'] = 'length';
 
+            }elseif($user_data['password'] !== $user_data['p_comfirm']){
+              //パスワードが４文字より少ない
+              $error['p_comfirm'] = 'notsame';
+
             }
+
+
+
+                
+                 
+            //    //モ デルを呼び出す
+                  // $user = new User();
+
+                  // if (!empty($return)) {
+                  
+                  // //モデルのcreateメソッドを実行する（モデルのcreateメソッドは、insert文を実行してブログを保存する）
+                  // $return = $user->signup();
+
+                  // header('Location:/tabilog/users/signup');
+
+                  // }
+                  
+
 
             
           //エラーがない場合に便利　
             if(empty($error)){
+
+                      
+                  // $return['email'] == $error['email'];
+
+                  // if(!empty($error['email'])){
+                   
+                  // header('Location:/tabilog/users/signup');
+                  // }
 
               //セッションに値を保存
               $_SESSION['join'] = $user_data;
@@ -119,17 +189,30 @@ session_start();
               //check.phpにへ遷移
 
               header('Location:/tabilog/users/check');
-              exit();
+              
             }
 
 
           //書き直し
           if(isset($_REQUEST['action']) && $_REQUEST['action']== 'rewrite'){
-            $_POST = $_SESSION['join'];
+            // $_POST = $_SESSION['join'];
+
+            $user_data = $_SESSION['join'];
             //画像の再選択エラーメッセージを表示するために必要
             $error['rewrite'] = true;
           }
         }
+
+
+
+
+
+
+  
+
+
+
+
           $resource = 'users';
           $action = 'signup';
           require('views/layout/application.php');
@@ -138,11 +221,7 @@ session_start();
 
       }
 
-      function comfirm() {
-          $resource = 'users';
-          $action = 'comfirm';
-          require('views/layout/application.php');
-      }
+      
 
 
       function check() {
@@ -180,14 +259,41 @@ session_start();
       //モデルのcreateメソッドを実行する（モデルのcreateメソッドは、insert文を実行してブログを保存する）
       $return = $user->create($user_data);
 
+      // header('Location:/tabilog/users/comfirm/$user_data["id"]');
       header('Location:/tabilog/users/thanks');
 
       }
 
+
+
+      // function comfirm($id) {
+
+
+      //       //モデルを呼び出す
+      // $user = new User();
+
+      // //モデルのshowメソッドを実行する（モデルのshowメソッドは、select文を実行してidで指定したブログデータを取得する）
+      // //モデルのshowメソッドに$idを引数として渡す
+      //   //モデルのshowメソッドから返ってきた取得結果を、変数に格納
+      // $return = $user->comfirm($id);
+      // header('Location:/tabilog/users/thanks');
+          
+      // }
+
       function thanks() {
+
+      //   $user = new User();
+      
+      // //モデルのcreateメソッドを実行する（モデルのcreateメソッドは、insert文を実行してブログを保存する）
+      //    $return = $user->thanks($user_data);
+
+      
           $resource = 'users';
           $action = 'thanks';
           require('views/layout/application.php');
+
+          unset($_SESSION['join']);
+
       }
 
       function login() {

--- a/models/user.php
+++ b/models/user.php
@@ -19,50 +19,59 @@
 		}
 
 		function signup(){
+			//重複アカウントのチェック
+					  // if(empty($error)){
+					    //入ったメールアドレスがデータべースに何件あるかカウントする
+					    $sql = sprintf('SELECT COUNT(*) AS cnt FROM users WHERE email="%s"',$_POST['email'] );
+					    // $record = mysqli_query($db, $sql) or die(mysqli_error($db));
+					    // $table = mysqli_fetch_assoc($record);
+
+					    //SQLの実行
+						$results = mysqli_query($this->dbconnect, $sql) or die(mysqli_error($this->dbconnect));
+
+
+						//実行結果を取得し、配列に格納
+						
+						$result = mysqli_fetch_assoc($results);
+
+					// 	//取得結果を返す
+					// 	// return $result;
+
+					//     //カウントした数が０以上ならエラーを起こす。duplicate(重複)のエラーを起こす。
+					    if($result['cnt'] > 0){
+					     return $result;
+					  }
+
+					// // //取得結果を返す
+						
+					//   // }
+					//     }
+
+					   // }
+
+					 //    //SQLの実行
+						// $results = mysqli_query($this->dbconnect, $sql) or die(mysqli_error($this->dbconnect));
+
+
+						
+						
+
+
+					
+
+			}
 
 
 					
 
 
-		}
+		
 
 
-		function confirm(){
-			
-			}
+		
 
-			function create($user_data){
+		function create($user_data){
 
-				// if(!empty($user_data)){
-  
-  
-					//   $sql = sprintf('INSERT INTO users SET user_name="%s", age="%d", sex="%d" email="%s", password="%s", u_created="now()"',
-					   
-					//     mysqli_real_escape_string($db, $_SESSION['join']['user_name']),
-					//     mysqli_real_escape_string($db, $_SESSION['join']['age']),
-					//     mysqli_real_escape_string($db, $_SESSION['join']['sex']),
-					//     mysqli_real_escape_string($db, $_SESSION['join']['email']),
-
-					//     // sha1(シャーワン)暗号化する関数　16進数の４０byteの文字列を取得する
-					//     mysqli_real_escape_string($db, sha1($_SESSION['join']['password']))
-					// );
-
-					   // $sql = sprintf("INSERT INTO `users`(`user_id`, `user_name`, `email`, `password`, `sex`, `age`, `u_created`, `u_modified`, `u_delete_flag`) 
-					   // 	VALUES (NULL,'%s','%s',sha1('%s'),'%d','%d',now(),CURRENT_TIMESTAMP,0);"
-					   // 	,$user_data['user_name'],$user_data['email'],$user_data['password'],$user_data['sex'],$user_data['age']
-					   // 	);
-
-
-
-					   // $sql = sprintf("INSERT INTO `users`(`user_id`, `user_name`, `email`, `password`, `sex`, `age`, `u_created`, `u_modified`, `u_delete_flag`) 
-					   // 	VALUES (NULL,'%s','%s',sha1('%s'),'%d','%d',now(),CURRENT_TIMESTAMP,0);",
-					   // 	mysqli_real_escape_string($db, $_SESSION['join']['user_name']),
-					   // 	mysqli_real_escape_string($db, $_SESSION['join']['email']),
-					   // 	mysqli_real_escape_string($db, sha1($_SESSION['join']['password'])),
-					   // 	mysqli_real_escape_string($db, $_SESSION['join']['sex']),
-					   // 	mysqli_real_escape_string($db, $_SESSION['join']['age'])
-
-					   // 	
 
 				 $sql = sprintf("INSERT INTO `users`(`user_id`, `user_name`, `email`, `password`, `sex`, `age`, `u_created`, `u_modified`, `u_delete_flag`) 
 					   	VALUES (NULL,'%s','%s',sha1('%s'),'%d','%d',now(),CURRENT_TIMESTAMP,0);",
@@ -86,7 +95,7 @@
 						
 
 					    // unset ここから使わないから存在しないよと表す。指定された変数の割当を解除する。ここではセッション情報を破棄している。
-					    unset($_SESSION['join']);
+					    // unset($_SESSION['join']);
 
 					    // header('Location:/Tabilog/users/thanks');
 					    // exit();
@@ -99,32 +108,61 @@
 			}
 
 			function check(){
-				//重複アカウントのチェック
-					 //  if(empty($error)){
-					 //    //入ったメールアドレスがデータべースに何件あるかカウントする
-					 //    $sql = sprintf('SELECT COUNT(*) AS cnt FROM users WHERE email="%s"',mysqli_real_escape_string($db, $_POST['email']) );
-					 //    $record = mysqli_query($db, $sql) or die(mysqli_error($db));
-					 //    $table = mysqli_fetch_assoc($record);
 
-					 //    //カウントした数が０以上ならエラーを起こす。duplicate(重複)のエラーを起こす。
-					 //    if($table['cnt'] > 0){
-					 //      $error['email'] = 'duplicate';
-					 //    }
-
-					 //    //SQLの実行
-						// $results = mysqli_query($this->dbconnect, $sql) or die(mysqli_error($this->dbconnect));
+		    }
 
 
-						
-						// //取得結果を返す
-						// return $results;
-					 //  }
 
 
-					
 
-			}
+		 //    function confirm($id){
 
+		 //    	$sql = sprintf("SELECT * FROM `users` WHERE `id` =%d",$id);
+			// //$sql = "SELECT * FROM `blogs` WHERE `delete_flag` = 0 AND `id` =$id"　上記と同じ効果
+
+			// //SQLの実行
+			// $results = mysqli_query($this->dbconnect, $sql) or die(mysqli_error($this->dbconnect));
+
+
+			// //実行結果を取得し、配列に格納
+			
+			// $result = mysqli_fetch_assoc($results);
+
+			// //取得結果を返す
+			// return $result;
+			
+			// }
+
+
+
+			function thanks(){
+
+
+			// 	$sql = sprintf("SELECT * FROM `users` WHERE `id` =%d",$id);
+			// // //$sql = "SELECT * FROM `blogs` WHERE `delete_flag` = 0 AND `id` =$id"　上記と同じ効果
+
+			// // //SQLの実行
+			// $results = mysqli_query($this->dbconnect, $sql) or die(mysqli_error($this->dbconnect));
+
+
+			// //実行結果を取得し、配列に格納
+			
+			// $result = mysqli_fetch_assoc($results);
+
+			// //取得結果を返す
+			// return $result;
+			
+			// }
+
+
+				  // unset($_SESSION['join']);
+
+			
+		}
+
+
+
+		
 
 	}
 ?>

--- a/views/users/check.php
+++ b/views/users/check.php
@@ -38,7 +38,7 @@
                                                          </div>
                                                          <div  class="col-md-3">
                                                          
-                                                           <a href="/tabilog/users/signup? action = rewrite" target="_blank" type="button" id="button" class="btn btn-primary btn-lg btn-block login-button">変更</a>
+                                                           <a href="/tabilog/users/signup?action=rewrite" target="_blank" type="button" id="button" class="btn btn-primary btn-lg btn-block login-button">変更</a>
                                                             <br><br> <br><br>
                                                         </div>
                                                         <div  class="col-md-3">

--- a/views/users/signup.php
+++ b/views/users/signup.php
@@ -23,15 +23,16 @@
                                                                         <span class="input-group-addon"><i class="fa fa-user fa" aria-hidden="true"></i></span>
 <!--                                                                         <input type="text" class="form-control" name="user_name" id="name"  placeholder="例：山田太郎"/>
 -->    
-                                                                            <?php if(isset($_POST['nick_name'])){ ?>
+                                                                            <?php if(isset($_POST['user_name'])){ ?>
                                                                               <input type="text" name="user_name" class="form-control" placeholder="例： 山田太郎 " value="<?php echo $_POST['user_name']; ?>">
                                                                               <?php }else{?>
                                                                               <input type="text" name="user_name" class="form-control" placeholder="例： 山田太郎" >
                                                                               <?php } ?>
-                                                                              <?php if(isset($error['user_name']) && $error['user_name'] == 'blank'): ?>
+                                                                              
+                                                                    </div>
+                                                                    <?php if(isset($error['user_name']) && $error['user_name'] == 'blank'): ?>
                                                                               <p class="error"> ※ニックネームを入力してください。</p>
                                                                             <?php endif; ?>
-                                                                 </div>
                                                                 </div>
                                                             </div>
 
@@ -40,8 +41,17 @@
                                                                 <div class="cols-sm-5">
                                                                     <div class="input-group">
                                                                         <span class="input-group-addon"><i class="glyphicon glyphicon-time" aria-hidden="true"></i></span>
-                                                                        <input type="text" class="form-control" name="age" id="name"  placeholder="例：20"/>
+
+                                                                        <?php if(isset($_POST['age'])){ ?>
+                                                                              <input type="text" name="age" class="form-control" placeholder="例： 20 " value="<?php echo $_POST['age']; ?>">
+                                                                              <?php }else{?>
+                                                                              <input type="text" name="age" class="form-control" placeholder="例： 20" >
+                                                                              <?php } ?>
+                                            
                                                                     </div>
+                                                                    <?php if(isset($error['age']) && $error['age'] == 'blank'): ?>
+                                                                              <p class="error"> ※年齢を入力してください。</p>
+                                                                            <?php endif; ?>
                                                                 </div>
                                                             </div>
                                                             <!-- ラジオボックス -->
@@ -54,6 +64,10 @@
                                                                             <div class="form-group has-feedback">
                                                                                 <label class="input-group">
                                                                                     <span class="input-group-addon">
+
+
+                                            
+
                                                                                         <input type="radio" name="sex" value="1" />
                                                                                     </span>
                                                                                     <div class="form-control form-control-static">
@@ -76,6 +90,9 @@
                                                                             </div>
                                                                         </div>
                                                                     </div>
+                                                                    <?php if(isset($error['sex']) && $error['sex'] == 'blank'): ?>
+                                                                              <p class="error"> ※性別を入力してください。</p>
+                                                                            <?php endif; ?>
                                                                 </div>
                                                             </div>
 
@@ -84,8 +101,23 @@
                                                                 <div class="cols-sm-10">
                                                                     <div class="input-group">
                                                                         <span class="input-group-addon"><i class="fa fa-envelope fa" aria-hidden="true"></i></span>
-                                                                        <input type="text" class="form-control" name="email" id="email"  placeholder="例：◯◯◯◯◯＠△△△△"/>
+                                                                       
+                                                                        <?php if(isset($_POST['email'])){ ?>
+                                                                          <input type="email" name="email" class="form-control" placeholder="例： tabi@log.com" value="<?php echo $_POST['email']; ?>">
+                                                                          <?php }else{?>
+                                                                          <input type="email" name="email" class="form-control" placeholder="例： tabi@log.com">
+                                                                          <?php } ?>
+                                                                         
                                                                     </div>
+                                                                     <?php if(isset($error['email']) && $error['email'] == 'blank'): ?>
+                                                                          <p class="error"> ※メールアドレスを入力してください。</p>
+                                                                        <?php endif; ?>
+
+                                                                        <!-- 重複登録時のエラー時 -->
+                                                                        <?php if($error['email'] == 'duplicate'): ?>
+                                                                        <p class="error">※　指定されたメールアドレスはすでに登録されています。</p>
+
+                                                                        <?php endif; ?>
                                                                 </div>
                                                             </div>
 
@@ -95,8 +127,30 @@
                                                                 <div class="cols-sm-10">
                                                                     <div class="input-group">
                                                                         <span class="input-group-addon"><i class="fa fa-envelope fa" aria-hidden="true"></i></span>
-                                                                        <input type="text" class="form-control" name="e_comfirm" id="email"  placeholder="例：◯◯◯◯◯＠△△△△"/>
+                                                                     
+                                                                    <?php if(isset($_POST['e_comfirm'])){ ?>
+                                                                          <input type="email" name="e_comfirm" class="form-control" placeholder="例： tabi@log.com" value="<?php echo $_POST['e_comfirm']; ?>">
+                                                                          <?php }else{?>
+                                                                          <input type="email" name="e_comfirm" class="form-control" placeholder="例： tabi@log.com">
+                                                                          <?php } ?>
+                                                                         
                                                                     </div>
+                                                                     <?php if(isset($error['e_comfirm']) && $error['e_comfirm'] == 'blank'): ?>
+                                                                          <p class="error"> ※メールアドレスを入力してください。</p>
+                                                                        <?php endif; ?>
+
+
+
+                                                                             <!-- 上記と違うメール時のエラー時 -->
+                                                                    <?php if(isset($error['e_comfirm']) && $error['e_comfirm'] == 'notsame'): ?>
+                                                                          <p class="error"> ※上記と同じメールアドレスを入力してください。</p>
+                                                                        <?php endif; ?>
+
+                                                                        <!-- 重複登録時のエラー時 -->
+                                                                        <?php if($error['email'] == 'duplicate'): ?>
+                                                                        <p class="error">※　指定されたメールアドレスはすでに登録されています。</p>
+
+                                                                        <?php endif; ?>
                                                                 </div>
                                                             </div>
 
@@ -106,18 +160,56 @@
                                                                 <div class="cols-sm-10">
                                                                     <div class="input-group">
                                                                         <span class="input-group-addon"><i class="fa fa-lock fa-lg" aria-hidden="true"></i></span>
-                                                                        <input type="password" class="form-control" name="password" id="password"  placeholder="パスワードは英数字８文字以上"/>
-                                                                    </div>
+                                                                        <!-- <input type="password" class="form-control" name="password" id="password"  placeholder="パスワードは英数字８文字以上"/> -->
+                                                                                 <?php if(isset($_POST['password'])){ ?>
+                                                                                  <input type="password" name="password" class="form-control" placeholder="パスワードは英数字８文字以上" value="<?php echo $_POST['password']; ?>">
+                                                                                  <?php }else{?>
+                                                                                  <input type="password" name="password" class="form-control" placeholder="パスワードは英数字８文字以上" >
+                                                                                   <?php } ?>
+                                                                     </div>
+                                                                                  <?php if(isset($error['password']) && $error['password'] == 'blank'): ?>
+                                                                                  <p class="error"> ※パスワードを入力してください。</p>
+                                                                                <?php endif; ?>
+                                                                                <?php if(isset($error['password']) && $error['password'] == 'length'): ?>
+                                                                                  <p class="error"> ※パスワードは英数８文字以上で入力してください。</p>
+                                                                                <?php endif; ?>
+                                                                   
                                                                 </div>
                                                             </div>
 
                                                             <div class="form-group">
                                                                 <label for="confirm" class="cols-sm-2 control-label">パスワード (確認用）</label>
                                                                 <div class="cols-sm-10">
-                                                                    <div class="input-group">
+                                                                   <!--  <div class="input-group">
                                                                         <span class="input-group-addon"><i class="fa fa-lock fa-lg" aria-hidden="true"></i></span>
                                                                         <input type="password" class="form-control" name="p_comfirm" id="confirm"  placeholder="パスワードは英数字８文字以上"/>
                                                                     </div>
+                                                                </div>
+                                                            </div> -->
+
+                                                                    <div class="input-group">
+                                                                        <span class="input-group-addon"><i class="fa fa-lock fa-lg" aria-hidden="true"></i></span>
+                                                                        <!-- <input type="password" class="form-control" name="password" id="password"  placeholder="パスワードは英数字８文字以上"/> -->
+                                                                                 <?php if(isset($_POST['p_comfirm'])){ ?>
+                                                                                  <input type="password" name="p_comfirm" class="form-control" placeholder="パスワードは英数字８文字以上" value="<?php echo $_POST['p_comfirm']; ?>">
+                                                                                  <?php }else{?>
+                                                                                  <input type="password" name="p_comfirm" class="form-control" placeholder="パスワードは英数字８文字以上" >
+                                                                                   <?php } ?>
+                                                                     </div>
+                                                                                   <?php if(isset($error['p_comfirm']) && $error['p_comfirm'] == 'blank'): ?>
+                                                                                  <p class="error"> ※パスワードを入力してください。</p>
+                                                                                <?php endif; ?>
+                                                                                <?php if(isset($error['p_comfirm']) && $error['p_comfirm'] == 'length'): ?>
+                                                                                  <p class="error"> ※パスワードは英数８文字以上で入力してください。</p>
+                                                                                <?php endif; ?>
+
+
+                                                                             <!-- 上記と違うメール時のエラー時 -->
+                                                                                <?php if(isset($error['p_comfirm']) && $error['p_comfirm'] == 'notsame'): ?>
+                                                                                      <p class="error"> ※上記と同じメールアドレスを入力してください。</p>
+                                                                                    <?php endif; ?>
+
+                                                                   
                                                                 </div>
                                                             </div>
                      </div>

--- a/views/users/thanks.php
+++ b/views/users/thanks.php
@@ -2,7 +2,7 @@
                                             <div class="col-md-12">
                                                 <div class="main-login main-center" style align="center">
                                                     <br><br> <br><br>  <br><br> <br><br> 
-                                                    <h1>◯◯◯◯　様</h1>
+                                                    <h1><?php echo htmlspecialchars($_SESSION['join']['user_name'],ENT_QUOTES,'UTF-8');?>　　様</h1>
                                                     <h1>ご登録完了いたしました。</h1>
                                                 </div>
                                             </div>


### PR DESCRIPTION
入力情報未入力、メールとパスワードの確認が同じでない場合、DBに登録されたメールアドレスを入力した場合、パスワードが8字以下の場合に確認画面に遷移しないようにしました。

サンクス画面で入力者名が出るようにした。